### PR TITLE
fix: Correct JSX syntax and type errors in Register.tsx

### DIFF
--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -6,7 +6,6 @@ import { z } from 'zod';
 import { Eye, EyeOff, Mail, Lock, Loader2 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { cn } from '../../utils/cn';
-import toast from 'react-hot-toast';
 
 const loginSchema = z.object({
   email: z.string().email('Email inválido'),

--- a/frontend/src/pages/auth/Register.tsx
+++ b/frontend/src/pages/auth/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -25,7 +25,9 @@ const registerSchema = z.object({
   descripcion: z.string().optional(),
   especialidad: z.string().optional(),
   horarioAtencion: z.string().optional(),
-  sitioWeb: z.string().url('Debe ser una URL válida').optional().transform(val => val === '' ? undefined : val)
+  sitioWeb: z.string().optional().refine((val) => !val || z.string().url().safeParse(val).success, {
+    message: "Debe ser una URL válida"
+  })
 }).refine((data) => data.password === data.confirmPassword, {
   message: "Las contraseñas no coinciden",
   path: ["confirmPassword"],
@@ -41,7 +43,6 @@ const Register: React.FC = () => {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [accessCode, setAccessCode] = useState('');
-  const [isAuthorized, setIsAuthorized] = useState(false);
   const [showAccessForm, setShowAccessForm] = useState(true);
   const [tipoRegistro, setTipoRegistro] = useState<RegistroTipo>('negocio');
   const [negociosDisponibles, setNegociosDisponibles] = useState<any[]>([]);
@@ -50,8 +51,6 @@ const Register: React.FC = () => {
   const {
     register,
     handleSubmit,
-    watch,
-    setValue,
     formState: { errors },
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
@@ -88,7 +87,6 @@ const Register: React.FC = () => {
     }
 
     if (isValid) {
-      setIsAuthorized(true);
       setShowAccessForm(false);
       toast.success(message);
     } else {
@@ -390,8 +388,8 @@ const Register: React.FC = () => {
                   <p className="mt-1 text-sm text-red-600">{errors.telefono.message}</p>
                 )}
               </div>
-          </div> 
-            </div>  
+            </div>
+
             {tipoRegistro === 'negocio' && (
               <div className="bg-blue-50 p-4 rounded-md">
                 <h3 className="text-lg font-medium text-gray-900 mb-4">Información del Consultorio</h3>


### PR DESCRIPTION
This pull request refines the registration form logic in `Register.tsx` by simplifying state management and improving the URL validation for the `sitioWeb` field. It also includes minor cleanup of unused imports and code.

**Registration Form Improvements:**

* Improved validation for the `sitioWeb` field: now uses a custom Zod `refine` to ensure the field is either empty or a valid URL, providing a clearer error message.
* Removed the unused `isAuthorized` state and its related logic, simplifying the flow for showing the access form.
* Cleaned up the useForm hook by removing unused `watch` and `setValue` variables.
* Removed the unnecessary `useEffect` import.

**General Cleanup:**

* Fixed minor formatting and removed an extra closing `div`.
* Removed an unused import of `toast` from `Login.tsx`.